### PR TITLE
Fix: Remove Host header for AppSec requests in Curl handler

### DIFF
--- a/src/Client/RequestHandler/Curl.php
+++ b/src/Client/RequestHandler/Curl.php
@@ -103,6 +103,17 @@ class Curl extends AbstractRequestHandler
         $url = $request->getUri();
         $parameters = $request->getParams();
         $rawBody = $request instanceof AppSecRequest ? $request->getRawBody() : '';
+
+        // For AppSec requests, remove Host header - let cURL set it from URL
+        // This matches the behavior in FileGetContents handler
+        if ($request instanceof AppSecRequest) {
+            /**
+             * It's not recommended to set the Host header explicitly.
+             * In all cases, for AppSec requests, the originating host is sent in the X-Crowdsec-Appsec-Host header.
+             */
+            unset($headers['Host']);
+        }
+
         $options = [
             \CURLOPT_HEADER => false,
             \CURLOPT_RETURNTRANSFER => true,


### PR DESCRIPTION
## Issue

The Curl request handler was forwarding the `Host` header from the original HTTP request when making AppSec requests, causing routing failures with reverse proxies that use host-based routing.

## Scenario

1. User accesses: `https://example.com`
2. Bouncer configured with: `appsec_url = https://appsec.domain.com`
3. Curl sends HTTP request to `appsec.domain.com` with `Host: example.com` header
4. Reverse proxy cannot route the request due to incorrect Host header

## Root Cause

Inconsistency between request handlers:
- `FileGetContents.php` - ✅ Already removes Host header for AppSec requests (line 168)
- `Curl.php` - ❌ Forwards all headers including Host

## Solution

Align `Curl.php` behavior with `FileGetContents.php` by removing the Host header for AppSec requests. The original host is already sent in the `X-Crowdsec-Appsec-Host` header for AppSec analysis.

## Testing

- ✅ Tested with Traefik reverse proxy
- ✅ AppSec requests route correctly  
- ✅ Original host preserved in `X-Crowdsec-Appsec-Host` header
- ✅ No impact on LAPI requests

## Affected Users

- Remote AppSec deployments with reverse proxies
- Shared hosting environments  
- Multi-tenant setups with virtual host routing

## References

- FileGetContents implementation: [`src/Client/RequestHandler/FileGetContents.php#L168`](https://github.com/crowdsecurity/php-common/blob/main/src/Client/RequestHandler/FileGetContents.php#L168)